### PR TITLE
Passing a helix-cli branch as parameter is never taken into account #4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,10 @@ jobs:
         # Prepare helix-cli to run the smoke tests
         - run:
             name: Clone helix-cli
-            command: git clone https://github.com/adobe/helix-cli.git
+            command: |
+                if [ -z ${GDM_MODULE_BRANCHES} ]; then GDM_MODULE_BRANCHES="{}"; fi
+                cli_branch=$(echo $GDM_MODULE_BRANCHES | jq -r 'if ."helix-cli" then ."helix-cli" else "master" end');
+                git clone --branch $cli_branch https://github.com/adobe/helix-cli.git
         
         - run:
             name: Debug message - branches being used in helix-cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
             command: |
                 if [ -z ${GDM_MODULE_BRANCHES} ]; then GDM_MODULE_BRANCHES="{}"; fi
                 cli_branch=$(echo $GDM_MODULE_BRANCHES | jq -r 'if ."helix-cli" then ."helix-cli" else "master" end');
+                echo "Using helix-cli branch: ${cli_branch}"
                 git clone --branch $cli_branch https://github.com/adobe/helix-cli.git
         
         - run:


### PR DESCRIPTION
PR for #4

I ran various tests, behave as expected:

helix-cli v0.2.1 (really old) + all the rest master: fails as expected because really uses v0.2.1 (and not master as before)https://circleci.com/gh/adobe/helix-continuous/371

helix-cli not specified + helix-shared v0.0.1 (really old): fails as expected (helix-cli is master
https://circleci.com/gh/adobe/helix-continuous/374

no param specified: success - all master
https://circleci.com/gh/adobe/helix-continuous/375
