### PR TITLE
Smoke test workflow sporadically fails while smoke tests were successful #9

### DIFF
--- a/.circleci/orbs/helix-smoke-tests/orb.yml
+++ b/.circleci/orbs/helix-smoke-tests/orb.yml
@@ -82,7 +82,7 @@ commands:
                     RUNNING=true
                         while [ $RUNNING == true ]; do
                         sleep 10;
-                        status=$(curl --silent --header "Accept: application/json" "${build_url}?circle-token=$1" | tee ${smoke_result_file} | jq -r '.status');
+                        status=$(curl --silent --header "Accept: application/json" "${build_url}?circle-token=$1" | tee ${smoke_result_file} | jq -r '.status' || echo '');
                         echo 'running queued scheduled not_running' | grep --silent "$status" || RUNNING=false;
                         echo -n "."
                     done


### PR DESCRIPTION
PR for #9 

If `jq` cannot parse the json, "catch" error ( `||` with `bash`) and echo an empty status. Like this the loop will continue to run instead of exiting the script. 
The error message will still be displayed which is still be good for now to observe if this happens often (which might be something to bring back to CircleCI...)